### PR TITLE
Remove Sprocket related types

### DIFF
--- a/Datamatic.py
+++ b/Datamatic.py
@@ -1,11 +1,17 @@
+"""
+A tool for generating code based on a schema of Components.
+"""
 import json
 import argparse
 import pathlib
 
-from Datamatic import Plugins, Validator, Generator
+from Datamatic import Plugins, Types, Validator, Generator
 
 
 def parse_args():
+    """
+    Read the command line.
+    """
     parser = argparse.ArgumentParser()
     parser.add_argument("-s", "--spec", required=True)
     parser.add_argument("-d", "--dir", required=True)
@@ -13,7 +19,11 @@ def parse_args():
 
 
 def main(args):
+    """
+    Entry point.
+    """
     Plugins.load_all(args.dir)
+    Types.load_all(args.dir)
 
     with open(args.spec) as specfile:
         spec = json.loads(specfile.read())

--- a/Datamatic.py
+++ b/Datamatic.py
@@ -4,6 +4,7 @@ A tool for generating code based on a schema of Components.
 import json
 import argparse
 import pathlib
+import sys
 import importlib
 
 from Datamatic import Plugins, Validator, Generator

--- a/Datamatic.py
+++ b/Datamatic.py
@@ -4,8 +4,18 @@ A tool for generating code based on a schema of Components.
 import json
 import argparse
 import pathlib
+import importlib
 
-from Datamatic import Plugins, Types, Validator, Generator
+from Datamatic import Plugins, Validator, Generator
+
+
+def discover(directory):
+    for file in pathlib.Path(directory).glob("**/*.dmx.py"):
+        name = file.parts[-1].split(".")[0]
+        spec = importlib.util.spec_from_file_location(name, str(file))
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
 
 
 def parse_args():
@@ -22,8 +32,7 @@ def main(args):
     """
     Entry point.
     """
-    Plugins.load_all(args.dir)
-    Types.load_all(args.dir)
+    discover(args.dir)
 
     with open(args.spec) as specfile:
         spec = json.loads(specfile.read())

--- a/Datamatic/Plugins.py
+++ b/Datamatic/Plugins.py
@@ -20,12 +20,3 @@ def compmethod(method):
 def attrmethod(method):
     method.__type = "Attr"
     return staticmethod(method)
-
-
-def load_all(directory):
-    for file in pathlib.Path(directory).glob("**/*.dm_plugin.py"):
-        name = file.parts[-1].split(".")[0]
-        spec = iu.spec_from_file_location(name, str(file))
-        module = iu.module_from_spec(spec)
-        sys.modules[spec.name] = module
-        spec.loader.exec_module(module)

--- a/Datamatic/Types.py
+++ b/Datamatic/Types.py
@@ -1,5 +1,7 @@
 from abc import ABC, abstractmethod
-
+import pathlib
+import sys
+import importlib.util as iu
 
 class CppType(ABC):
     @abstractmethod
@@ -64,89 +66,18 @@ class String(CppType):
         return "std::string"
 
 
-class Vec2(CppType):
-    def __init__(self, val):
-        assert isinstance(val, list)
-        assert all([isinstance(x, float) for x in val])
-        self.x, self.y = [Float(t) for t in val]
-
-    def __repr__(self):
-        return f'{self.typename()}{{{self.x}, {self.y}}}'
-
-    @staticmethod
-    def typename():
-        return "Maths::vec2"
-
-
-class Vec3(CppType):
-    def __init__(self, val):
-        assert isinstance(val, list)
-        assert all([isinstance(x, float) for x in val])
-        self.x, self.y, self.z = [Float(t) for t in val]
-
-    def __repr__(self):
-        return f'{self.typename()}{{{self.x}, {self.y}, {self.z}}}'
-
-    @staticmethod
-    def typename():
-        return "Maths::vec3"
-
-
-class Vec4(CppType):
-    def __init__(self, val):
-        assert isinstance(val, list)
-        assert all([isinstance(x, float) for x in val])
-        self.x, self.y, self.z, self.w = [Float(t) for t in val]
-
-    def __repr__(self):
-        return f'{self.typename()}{{{self.x}, {self.y}, {self.z}, {self.w}}}'
-
-    @staticmethod
-    def typename():
-        return "Maths::vec4"
-
-
-class Quat(CppType):
-    def __init__(self, val):
-        assert isinstance(val, list)
-        assert all([isinstance(x, float) for x in val])
-        self.x, self.y, self.z, self.w = [Float(t) for t in val]
-
-    def __repr__(self):
-        return f'{self.typename()}{{{self.x}, {self.y}, {self.z}, {self.w}}}'
-
-    @staticmethod
-    def typename():
-        return "Maths::quat"
-
-
-class Mat4(CppType): # TODO: Implement
-    def __init__(self, val):
-        pass
-
-    def __repr__(self):
-        return f"{self.typename()}{{1.0}}"
-
-    @staticmethod
-    def typename():
-        return "Maths::mat4"
-
-
-class QueueVec3(CppType): # TODO: Implement
-    def __init__(self, val):
-        pass
-
-    def __repr__(self):
-        return f"{self.typename()}{{}}"
-
-    @staticmethod
-    def typename():
-        return "std::queue<Maths::vec3>"
-
-
 def get(typename):
     for cls in CppType.__subclasses__():
         if cls.typename() == typename:
             return cls
     print(f"Could not find {typename}")
     return None
+
+
+def load_all(directory):
+    for file in pathlib.Path(directory).glob("**/*.dm_type.py"):
+        name = file.parts[-1].split(".")[0]
+        spec = iu.spec_from_file_location(name, str(file))
+        module = iu.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)

--- a/Datamatic/Types.py
+++ b/Datamatic/Types.py
@@ -72,12 +72,3 @@ def get(typename):
             return cls
     print(f"Could not find {typename}")
     return None
-
-
-def load_all(directory):
-    for file in pathlib.Path(directory).glob("**/*.dm_type.py"):
-        name = file.parts[-1].split(".")[0]
-        spec = iu.spec_from_file_location(name, str(file))
-        module = iu.module_from_spec(spec)
-        sys.modules[spec.name] = module
-        spec.loader.exec_module(module)

--- a/Datamatic/Validator.py
+++ b/Datamatic/Validator.py
@@ -1,3 +1,7 @@
+"""
+Validates a given schema to make sure it is well-formed. This should
+also serve as documentation for what makes a valid schema.
+"""
 from Datamatic import Types
 
 COMP_KEYS_REQ = {
@@ -24,6 +28,9 @@ ATTR_KEYS_OPT = {
 }
 
 def validate_attribute(attr):
+    """
+    Asserts that the given attribute is well-formed.
+    """
     assert ATTR_KEYS_REQ <= set(attr.keys()), attr
     assert set(attr.keys()) <= ATTR_KEYS_REQ | ATTR_KEYS_OPT, attr
 
@@ -32,10 +39,7 @@ def validate_attribute(attr):
 
     cls = Types.get(attr["Type"])
     assert cls is not None
-    obj = cls(attr["Default"]) # Will assert if invalid
-
-    if attr["Type"] == "Maths::mat4": # TODO: Remove this
-        assert attr["Scriptable"] is False, "Maths::mat4 is currently not scriptable"
+    cls(attr["Default"]) # Will assert if invalid
 
     if "Scriptable" in attr:
         assert isinstance(attr["Scriptable"], bool), attr
@@ -44,6 +48,9 @@ def validate_attribute(attr):
 
 
 def validate_component(comp):
+    """
+    Asserts that the given component is well-formed.
+    """
     assert COMP_KEYS_REQ <= set(comp.keys()), comp
     assert set(comp.keys()) <= COMP_KEYS_REQ | COMP_KEYS_OPT, comp
 
@@ -59,6 +66,10 @@ def validate_component(comp):
 
 
 def run(spec):
+    """
+    Runs the validator against the given spec, raising an exception if there
+    is an error in the schema.
+    """
     assert set(spec.keys()) == {"Version", "Components"}
 
     assert isinstance(spec["Version"], int)

--- a/README.md
+++ b/README.md
@@ -28,10 +28,16 @@ will place alongside the template files with the `.dm` removed. So far, it has b
 
 This is currently changing a lot as Datamatic evolves, see [here](Datamatic/Validator.py) to see the current schema validator.
 
+### Types
+
+The basic types that are supported by default are int, float, bool and std::string. Users can define new types by subclassing CppType. These can be placed anywhere
+inside the target repo within a `*.dmx.py` file and Datamatic will automatically discover it.
+
 ### Plugins
 
 The syntax for Datamatic is very simple, and as such it may not be capable of generating the desired code. To this end, it is possible to create Plugins to allow
-users to define text replacement functions using the full power of Python. These can be placed anywhere inside the target repo and Datamatic will discover them.
+users to define text replacement functions using the full power of Python. These can be placed anywhere inside the target repo within a `*.dmx.py` file and
+Datamatic will discover them.
 
 ![Plugins](res/Plugin.png)
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,5 @@ This is going to be generalised. Currently, extra flags can be defined by users 
 
 ## Future
 - Generalise the flags concept and remove hardcoded flags from the core library.
-- Remove the hardcoded `Maths::*` types. These are artifacts from my game engine project. It should be possible for users to define custom types. `int`, `float`, `bool`
-  and `std::string` will be considered as "built in" types. These will either be specified within the spec file or be done in a similar way to Plugins as python files
-  that get automatically discovered.
 - Look into other language support. Currently only C++ is properly supported. I have used this to generate Lua code as well, but most of that is done with a Plugin,
   whereas I'd like Datamatic to be more language agnostic, considering the bulk of the language specific stuff lives in the template files themselves.


### PR DESCRIPTION
- Removed all the `Maths::*` types as they were specific to my Sprocket game engine.
- Changed the suffix of the `*.dm_plugin.py` files to `*.dmx.py`. These files can now also have types defined in them.