### PR TITLE
General Flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-__pycache__/
-Datamatic/__pycache__/
-Plugins/__pycache__/
+**/__pycache__/
+.vscode/

--- a/Datamatic.py
+++ b/Datamatic.py
@@ -17,6 +17,17 @@ def discover(directory):
         spec.loader.exec_module(module)
 
 
+def fill_flag_defaults(spec):
+    defaults = {flag["Name"]: flag["Default"] for flag in spec["Flags"]}
+
+    for comp in spec["Components"]:
+        comp_flags = comp.get("Flags", {})
+        comp["Flags"] = {**defaults, **comp_flags}
+        for attr in comp["Attributes"]:
+            attr_flags = attr.get("Flags", {})
+            attr["Flags"] = {**defaults, **attr_flags}
+
+
 def parse_args():
     """
     Read the command line.
@@ -52,6 +63,8 @@ def main(args):
 
     with args.spec.open() as specfile:
         spec = json.loads(specfile.read())
+
+    fill_flag_defaults(spec)
 
     Validator.run(spec)
 

--- a/Datamatic/Generator.py
+++ b/Datamatic/Generator.py
@@ -69,18 +69,16 @@ def attr_repl(matchobj, attr, flags):
 
 
 def get_attrs(comp, flags):
-    attrs = comp["Attributes"] 
-    if "SAVABLE" in flags:
-        attrs = [x for x in attrs if x.get("Savable", True)]
-    if "SCRIPTABLE" in flags:
-        attrs = [x for x in attrs if x.get("Scriptable", True)]
+    attrs = comp["Attributes"]
+    for key, value in flags.items():
+        attrs = [x for x in attrs if x[key] == value]
     return attrs
 
 
 def get_comps(spec, flags):
     comps = spec["Components"]
-    if "SCRIPTABLE" in flags:
-        comps = [x for x in comps if x.get("Scriptable", True)]
+    for key, value in flags.items():
+        attrs = [x for x in comps if x[key] == value]
     return comps
 
 
@@ -109,6 +107,22 @@ def get_header(dst):
     return "// GENERATED FILE\n"
 
 
+def parse_flag_val(val):
+    assert val in {"true", "false"}
+    return True if val == "true" else False
+
+
+def parse_flags(flags):
+    parsed_flags = {}
+    for flag in flags:
+        flag = flag.split("=")
+        assert len(flag) == 2
+        name = flag[0]
+        val = parse_flag_val(flag[1])
+        parsed_flags[name] = val
+    return parsed_flags
+
+
 def run(spec, src):
     dst = src.parent / src.name.replace(".dm.", ".")
 
@@ -133,7 +147,7 @@ def run(spec, src):
         elif line.startswith("#ifdef DATAMATIC_BLOCK"):
             assert not in_block
             in_block = True
-            flags = set(line.split()[2:])
+            flags = parse_flags(set(line.split()[2:]))
         else:
             out += line + "\n"
 

--- a/Datamatic/Generator.py
+++ b/Datamatic/Generator.py
@@ -71,14 +71,14 @@ def attr_repl(matchobj, attr, flags):
 def get_attrs(comp, flags):
     attrs = comp["Attributes"]
     for key, value in flags.items():
-        attrs = [x for x in attrs if x[key] == value]
+        attrs = [x for x in attrs if x["Flags"][key] == value]
     return attrs
 
 
 def get_comps(spec, flags):
     comps = spec["Components"]
     for key, value in flags.items():
-        attrs = [x for x in comps if x[key] == value]
+        comps = [x for x in comps if x["Flags"][key] == value]
     return comps
 
 

--- a/Datamatic/Validator.py
+++ b/Datamatic/Validator.py
@@ -13,7 +13,7 @@ COMP_KEYS_REQ = {
 
 
 COMP_KEYS_OPT = {
-    "Scriptable"
+    "Flags"
 }
 
 
@@ -26,9 +26,14 @@ ATTR_KEYS_REQ = {
 
 
 ATTR_KEYS_OPT = {
-    "Scriptable",
-    "Savable",
-    "Data",
+    "Flags",
+    "Custom"
+}
+
+
+FLAG_KEYS = {
+    "Name",
+    "Default"
 }
 
 
@@ -46,10 +51,20 @@ def validate_attribute(attr):
     assert cls is not None
     cls(attr["Default"]) # Will assert if invalid
 
-    if "Scriptable" in attr:
-        assert isinstance(attr["Scriptable"], bool), attr
-    if "Savable" in attr:
-        assert isinstance(attr["Savable"], bool), attr
+    if "Flags" in attr:
+        assert isinstance(attr["Flags"], dict)
+        for key, val in attr["Flags"].items():
+            assert isinstance(key, str)
+            assert isinstance(val, bool)
+
+
+def validate_flag(flag):
+    """
+    Asserts that the given flag is well-formed.
+    """
+    assert set(flag.keys()) == FLAG_KEYS
+    assert isinstance(flag["Name"], str)
+    assert isinstance(flag["Default"], bool)
 
 
 def validate_component(comp):
@@ -63,8 +78,11 @@ def validate_component(comp):
     assert isinstance(comp["DisplayName"], str), comp
     assert isinstance(comp["Attributes"], list), comp
 
-    if "Scriptable" in comp:
-        assert isinstance(comp["Scriptable"], bool)
+    if "Flags" in comp:
+        assert isinstance(comp["Flags"], dict)
+        for key, val in comp["Flags"].items():
+            assert isinstance(key, str)
+            assert isinstance(val, bool)
 
     for attr in comp["Attributes"]:
         validate_attribute(attr)
@@ -75,10 +93,14 @@ def run(spec):
     Runs the validator against the given spec, raising an exception if there
     is an error in the schema.
     """
-    assert set(spec.keys()) == {"Version", "Components"}
+    assert set(spec.keys()) == {"Version", "Flags", "Components"}
 
     assert isinstance(spec["Version"], int)
+    assert isinstance(spec["Flags"], list)
     assert isinstance(spec["Components"], list)
+
+    for flag in spec["Flags"]:
+        validate_flag(flag)
 
     for comp in spec["Components"]:
         validate_component(comp)


### PR DESCRIPTION
- It is now possible to specify a list of flags in the component spec JSON, along with default values. For each component and attribute, they can now contain a dictionary of flags.
- `Scriptable` and `Savable` have been removed. If this functionality is needed again, users can add these into the flags section of their json spec and migrate to using that.
- Flags specified in `#ifdef DATAMATIC_BLOCK <FLAGS>` must now be of the form `NAME=VALUE` where `VALUE` must be either `true` or `false. Adding these flags constrains the Datamatic block to only loop over components and attributes that have the value of the flag.
- `Data` has been renamed to `Custom` to better reflect that the intention of this block is to add custom data for use in plugins.